### PR TITLE
[feature] add dropout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Example usage:
 model = ConvLSTM(input_dim=channels,
                  hidden_dim=[64, 64, 128],
                  kernel_size=(3, 3),
-                 num_layers=3,
+                 num_layers=3, 
+                 dropout=0.1,
                  batch_first=True
                  bias=True,
                  return_all_layers=False)


### PR DESCRIPTION
Add the dropout parameter to ConvLSTM, which defaults to 0.0. For num_layers to 1, dropout does not work; For num_layers greater than 1, dropout works on the output of each layer except the last.